### PR TITLE
Handle select[multiple] value set in bindElementChangeToModel

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,17 @@ module.exports = function (tag) {
       _.set(tag, modelPath, e.target.value)
     }
     el.addEventListener('change', handler)
-    el.value = _.get(tag, modelPath)
+    if (el.attributes['multiple']) {
+      var value = _.get(tag, modelPath)
+      for (var i = 0 ; i < el.children.length ; i++) {
+        var option = el.children[i]
+        if (value.indexOf(option.value) !== -1) {
+          option.selected = true
+        }
+      }
+    } else {
+      el.value = _.get(tag, modelPath)
+    }
     modelBindCache.push({
       el: el,
       fn: handler


### PR DESCRIPTION
# Handle value setting for `<select multiple></select>`

Setting value for `<select multiple>` element differs with setting value to other inputs/selects that are not multiple.

In order to set value to multiple select, you have to iterate through every `<option>` child and set its `selected` property if needed. [more info here](http://stackoverflow.com/questions/16582901/javascript-jquery-set-values-selection-in-a-multiple-select)
