### PR TITLE
set default value to [] for multiple select

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ module.exports = function (tag) {
     }
     el.addEventListener('change', handler)
     if (el.attributes['multiple']) {
-      var value = _.get(tag, modelPath)
+      var value = _.get(tag, modelPath) || []
       for (var i = 0 ; i < el.children.length ; i++) {
         var option = el.children[i]
         if (value.indexOf(option.value) !== -1) {


### PR DESCRIPTION
# Set default `[]` value for multiple selects

When there is (lets say) new document, `undefined` or `''` might be passed to the `tag-value` property on multiple select. We handle this by setting the default value to `[]` **only** on the multiple select edge-case
