### PR TITLE
improve textarea/input to show empty string instead undefined when value is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,13 +73,14 @@ module.exports = function (tag) {
   }
 
   var bindElementChangeToModel = function (el) {
+    var value
     var modelPath = el.attributes['tag-value'].value.split('#')[1]
     var handler = function (e) {
       _.set(tag, modelPath, e.target.value)
     }
     el.addEventListener('change', handler)
     if (el.attributes['multiple']) {
-      var value = _.get(tag, modelPath) || []
+      value = _.get(tag, modelPath) || []
       for (var i = 0 ; i < el.children.length ; i++) {
         var option = el.children[i]
         if (value.indexOf(option.value) !== -1) {
@@ -87,7 +88,15 @@ module.exports = function (tag) {
         }
       }
     } else {
-      el.value = _.get(tag, modelPath)
+      value = _.get(tag, modelPath)
+
+      if (typeof value === 'undefined' &&
+          ['button', 'radio', 'checkbox'].indexOf(el.type) === -1 &&
+          ['INPUT', 'TEXTAREA'].indexOf(el.nodeName) !== -1) {
+        value = null
+      }
+
+      el.value = value
     }
     modelBindCache.push({
       el: el,


### PR DESCRIPTION
## What is done:
1. Improve `bind-tag` functionality when working with textareas/inputs:
   - show empty string, when `model/obj` value is `undefined`
## Why:
1. Shows `undefined` as value instead empty string
